### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that provides access to Amazon Managed Prometheus workspaces using the FastMCP SDK and `uv` for fast Python package management.
 
+<a href="https://glama.ai/mcp/servers/@sigitp-git/prometheus-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sigitp-git/prometheus-mcp-server/badge" alt="Amazon Managed Prometheus Server MCP server" />
+</a>
+
 ## Features
 
 - List Amazon Managed Prometheus workspaces


### PR DESCRIPTION
This PR adds a badge for the [Amazon Managed Prometheus MCP Server](https://glama.ai/mcp/servers/@sigitp-git/prometheus-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sigitp-git/prometheus-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sigitp-git/prometheus-mcp-server/badge" alt="Amazon Managed Prometheus Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.